### PR TITLE
Add bug-bot background watcher

### DIFF
--- a/.cursor/background.yml
+++ b/.cursor/background.yml
@@ -1,0 +1,10 @@
+name: bug-bot
+root: .
+watch:
+  - path: ".github/workflows/build.yml"
+    on_fail: "open_github_issue('CI build failed on {{commit}}')"
+  - path: "scripts/check_size.sh"
+    on_fail: "open_github_issue('Binary too large after {{commit}}')"
+env: { BOT_PAT: '${{ secrets.BOT_PAT }}' }
+setup: []
+command: "true"


### PR DESCRIPTION
## Summary
- add `.cursor/background.yml` to automatically open issues on build failures or size guard violations

## Testing
- `yq '.' .cursor/background.yml`

------
https://chatgpt.com/codex/tasks/task_e_686f9277e9c8832cba7252ac1d65c253