### PR TITLE
Switch to uv for dependency management

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -62,8 +62,10 @@ jobs:
             zip \
             python3-pip
 
-          pip3 install --upgrade pip
-          pip3 install qmk
+          pip3 install uv
+          uv venv
+          source .venv/bin/activate
+          uv pip install qmk
 
       - name: Build firmware
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,10 @@ jobs:
             gcc-arm-none-eabi \
             gcc-avr \
             python3-pip
-          pip3 install qmk
+          pip3 install uv
+          uv venv
+          source .venv/bin/activate
+          uv pip install qmk
 
       - name: Test build configuration
         run: |
@@ -114,7 +117,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang graphviz
-          pip3 install pydot
+          pip3 install uv
+          uv venv
+          source .venv/bin/activate
+          uv pip install pydot
       - name: Build call graph
         run: python3 tools/callgraph.py
       - name: Upload artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,11 @@ You can use these commands in PR comments:
 brew install qmk/qmk/qmk
 
 # Install dependencies (Linux)
-sudo apt-get install -y git python3-pip
-pip3 install qmk
+sudo apt-get install -y git
+pip3 install uv
+uv venv
+source .venv/bin/activate
+uv pip install qmk
 qmk setup -y
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ distclean_userspace: clean
 endif
 
 # Extra targets for formatting and/or pytest, running within the qmk/qmk_cli container to match GHA.
-CONTAINER_PREAMBLE := export HOME="/tmp"; export PATH="/tmp/.local/bin:\$$PATH"; python3 -m pip install --upgrade pip; python3 -m pip install -r requirements-dev.txt
+CONTAINER_PREAMBLE := export HOME="/tmp"; export PATH="/tmp/.local/bin:\$$PATH"; pip3 install uv; uv venv; source .venv/bin/activate; uv pip install -r requirements-dev.txt
 
 .PHONY: format-core
 format-core:

--- a/docs/ChangeLog/20220528.md
+++ b/docs/ChangeLog/20220528.md
@@ -50,7 +50,7 @@ On Windows, if using _QMK MSYS_ or _msys2_, you'll need to run the following com
 
 ```sh
 pacman --needed --noconfirm --disable-download-timeout -S mingw-w64-x86_64-python-pillow
-python3 -m pip install --upgrade qmk
+uv pip install --upgrade qmk
 ```
 
 On macOS:
@@ -63,7 +63,7 @@ brew upgrade qmk/qmk/qmk
 On Linux or WSL:
 
 ```sh
-python3 -m pip install --user --upgrade qmk
+uv pip install --user --upgrade qmk
 ```
 
 ### Updated Keyboard Codebases {#updated-keyboard-codebases}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,12 +18,14 @@ export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```
 
-### Install Using pip {#install-using-easy_install-or-pip}
+### Install Using uv {#install-using-easy_install-or-pip}
 
-If your system is not listed above you can install QMK manually. First ensure that you have Python 3.7 (or later) installed and have installed pip. Then install QMK with this command:
+If your system is not listed above you can install QMK manually. First ensure that you have Python 3.7 (or later) installed and have uv available. Create a virtual environment and install QMK with these commands:
 
 ```
-python3 -m pip install qmk
+uv venv
+source .venv/bin/activate
+uv pip install qmk
 export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```

--- a/docs/cli_development.md
+++ b/docs/cli_development.md
@@ -13,9 +13,11 @@ If you intend to maintain keyboards and/or contribute to QMK, you can enable the
 `qmk config user.developer=True`
 
 This will allow you to see all available subcommands.  
-**Note:** You will have to install additional requirements:  
+**Note:** You will have to install additional requirements:
 ```
-python3 -m pip install -r requirements-dev.txt
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements-dev.txt
 ```
 
 # Subcommands

--- a/docs/features/autocorrect.md
+++ b/docs/features/autocorrect.md
@@ -80,7 +80,7 @@ The solution is to set a word break : before and/or after the typo to constrain 
 
 :thier: is most restrictive, matching only when thier is a whole word.
 
-The `qmk generate-autocorrect-data` commands can make an effort to check for entries that would false trigger as substrings of correct words. It searches each typo against a dictionary of 25K English words from the english_words Python package, provided it’s installed. (run `python3 -m pip install english_words` to install it.)
+The `qmk generate-autocorrect-data` commands can make an effort to check for entries that would false trigger as substrings of correct words. It searches each typo against a dictionary of 25K English words from the english_words Python package, provided it’s installed. (run `uv pip install english_words` to install it.)
 
 ::: tip
 Unfortunately, this is limited to just english words, at this point.

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -98,7 +98,9 @@ You will need to install Git and Python. It's very likely that you already have 
 Install the QMK CLI by running:
 
 ```sh
-python3 -m pip install --user qmk
+uv venv
+source .venv/bin/activate
+uv pip install qmk
 ```
 
 #### Community Packages

--- a/keyboards/ducky/one2mini/1861st/readme.md
+++ b/keyboards/ducky/one2mini/1861st/readme.md
@@ -20,7 +20,7 @@ This firmware was tested on the duckyon2mini 1861ST version. To enter the 1861ST
 
 There are then two ways to flash the keyboard:
 
-    pip install --user nuvoton-isp
+    uv pip install --user nuvoton-isp
     nuvoisp -f ducky_one2mini_default.bin
 
 Alternatively you can use elfmimi's [nu-isp-cli](https://lib.rs/crates/nu-isp-cli) which is more complete than nuvoisp and allows flashing .hex files as well.

--- a/keyboards/ducky/one2sf/1967st/readme.md
+++ b/keyboards/ducky/one2sf/1967st/readme.md
@@ -23,7 +23,7 @@ To enter the 1967ST bootloader to flash, boot the keyboard while holding D+L.
 
 There are then two ways to flash the keyboard:
 
-    pip install --user nuvoton-isp
+    uv pip install --user nuvoton-isp
     nuvoisp -f ducky_one2sf_ansi.bin
 
 Alternatively you can use elfmimi's [nu-isp-cli](https://lib.rs/crates/nu-isp-cli) which is more complete than nuvoisp and allows flashing .hex files as well.

--- a/keyboards/ergodox_ez/util/keymap_beautifier/Dockerfile
+++ b/keyboards/ergodox_ez/util/keymap_beautifier/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7.4-alpine3.10
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --no-cache-dir -r requirements.txt
 COPY ./KeymapBeautifier.py ./KeymapBeautifier.py
 
 CMD [ "python", "./KeymapBeautifier.py", "-h" ]

--- a/keyboards/ergodox_ez/util/keymap_beautifier/README.md
+++ b/keyboards/ergodox_ez/util/keymap_beautifier/README.md
@@ -95,7 +95,7 @@ The prettified file is written to `output.c`. See the section Tweaks for non-def
 ### Without docker
 Requirements:
 * python3 (tested on 3.7.4)
-* python module `pycparser` installed (with `pip install pycparser`)
+* python module `pycparser` installed (with `uv pip install pycparser`)
 
 To run:
 ```

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -100,7 +100,7 @@ def _install_deps(requirements):
 
     If we detect that we are running in a virtualenv we can't write into we'll use sudo to perform the pip install.
     """
-    command = [sys.executable, '-m', 'pip', 'install']
+    command = [sys.executable, '-m', 'uv', 'pip', 'install']
 
     if sys.prefix != sys.base_prefix:
         # We are in a virtualenv, check to see if we need to use sudo to write to it
@@ -218,7 +218,7 @@ milc_version = __VERSION__.split('.')
 if int(milc_version[0]) < 2 and int(milc_version[1]) < 4:
     requirements = Path('requirements.txt').resolve()
 
-    _eprint(f'Your MILC library is too old! Please upgrade: python3 -m pip install -U -r {str(requirements)}')
+    _eprint(f'Your MILC library is too old! Please upgrade: uv venv && uv pip install -U -r {str(requirements)}')
     exit(127)
 
 # Make sure we can run binaries in the same directory as our Python interpreter
@@ -228,7 +228,7 @@ if python_dir not in os.environ['PATH'].split(os.pathsep):
     os.environ['PATH'] = os.pathsep.join((python_dir, os.environ['PATH']))
 
 # Check to make sure we have all our dependencies
-msg_install = f'\nPlease run `{sys.executable} -m pip install -r %s` to install required python dependencies.'
+msg_install = f'\nPlease run `uv venv` and `{sys.executable} -m uv pip install -r %s` to install required python dependencies.'
 args = sys.argv[1:]
 while args and args[0][0] == '-':
     del args[0]

--- a/lib/python/qmk/cli/generate/autocorrect_data.py
+++ b/lib/python/qmk/cli/generate/autocorrect_data.py
@@ -69,12 +69,12 @@ def parse_file(file_name: str) -> List[Tuple[str, str]]:
         from english_words import english_words_lower_alpha_set as correct_words
         if not cli.args.quiet:
             cli.echo('The english_words package is outdated, update by running:')
-            cli.echo('  {fg_cyan}python3 -m pip install english_words --upgrade')
+            cli.echo('  {fg_cyan}uv pip install english_words --upgrade')
     except ImportError:
         if not cli.args.quiet:
             cli.echo('Autocorrection will falsely trigger when a typo is a substring of a correctly spelled word.')
             cli.echo('To check for this, install the english_words package and rerun this script:')
-            cli.echo('  {fg_cyan}python3 -m pip install english_words')
+            cli.echo('  {fg_cyan}uv pip install english_words')
         # Use a minimal word list as a fallback.
         correct_words = ('information', 'available', 'international', 'language', 'loosest', 'reference', 'wealthier', 'entertainment', 'association', 'provides', 'technology', 'statehood')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "allie-cat-keeb"
+version = "0.1.0"
+description = "Vial-enabled QMK firmware"
+dependencies = [
+    "argcomplete",
+    "colorama",
+    "dotty-dict",
+    "hid",
+    "hjson",
+    "jsonschema>=4",
+    "milc>=1.4.2",
+    "pygments",
+    "pyserial",
+    "pyusb",
+    "pillow",
+    "qmk",
+]
+
+[project.optional-dependencies]
+ dev = [
+    "nose2",
+    "flake8",
+    "pep8-naming",
+    "pyflakes",
+    "yapf",
+ ]

--- a/readme.md
+++ b/readme.md
@@ -89,10 +89,13 @@ lily58_rev1_via_[configuration]_[side].uf2
    brew install qmk/qmk/qmk
    
    # Linux/WSL
-   sudo apt-get update
-   sudo apt-get install -y git python3-pip
-   pip3 install qmk
-   qmk setup -y
+  sudo apt-get update
+  sudo apt-get install -y git
+  pip3 install uv
+  uv venv
+  source .venv/bin/activate
+  uv pip install qmk
+  qmk setup -y
    ```
 
 ### Quick Build

--- a/util/install/arch.sh
+++ b/util/install/arch.sh
@@ -13,5 +13,7 @@ _qmk_install() {
 
     sudo pacman --needed  --noconfirm -S hidapi  # This will fail if the community repo isn't enabled
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/debian.sh
+++ b/util/install/debian.sh
@@ -24,5 +24,7 @@ _qmk_install() {
             binutils-riscv64-unknown-elf
     fi
 
-    python3 -m pip install --user -r "$QMK_FIRMWARE_DIR"/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r "$QMK_FIRMWARE_DIR"/requirements.txt
 }

--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -21,5 +21,7 @@ _qmk_install() {
         || sudo dnf $SKIP_PROMPT install libusb1-devel libusb-compat-0.1-devel \
         || sudo dnf $SKIP_PROMPT install libusb0-devel
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/freebsd.sh
+++ b/util/install/freebsd.sh
@@ -14,5 +14,6 @@ _qmk_install() {
         arm-none-eabi-binutils arm-none-eabi-gcc arm-none-eabi-newlib \
         avrdude dfu-programmer dfu-util
 
-    sudo python3 -m pip install -r $QMK_FIRMWARE_DIR/requirements.txt
+    sudo uv venv "$QMK_FIRMWARE_DIR/.venv"
+    sudo bash -c "source '$QMK_FIRMWARE_DIR/.venv/bin/activate' && uv pip install -r '$QMK_FIRMWARE_DIR/requirements.txt'"
 }

--- a/util/install/gentoo.sh
+++ b/util/install/gentoo.sh
@@ -30,5 +30,7 @@ _qmk_install() {
     sudo crossdev -s4 --stable --g \<9 --portage --verbose --target avr
     sudo crossdev -s4 --stable --g \<9 --portage --verbose --target arm-none-eabi
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/slackware.sh
+++ b/util/install/slackware.sh
@@ -21,5 +21,7 @@ _qmk_install() {
         python3 \
         avrdude dfu-programmer dfu-util teensy_loader_cli
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/solus.sh
+++ b/util/install/solus.sh
@@ -15,5 +15,7 @@ _qmk_install() {
         arm-none-eabi-binutils arm-none-eabi-gcc arm-none-eabi-newlib \
         avrdude dfu-programmer dfu-util
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/void.sh
+++ b/util/install/void.sh
@@ -11,5 +11,7 @@ _qmk_install() {
         avrdude dfu-programmer dfu-util teensy_loader_cli \
         libusb-compat-devel
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    uv venv "$QMK_FIRMWARE_DIR/.venv"
+    source "$QMK_FIRMWARE_DIR/.venv/bin/activate"
+    uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
## Summary
- install python dependencies using uv
- update docs to reference uv
- ensure CI workflows and Makefile use uv
- update install scripts for uv
- tweak CLI to use uv for auto-installs
- add pyproject for uv venv

## Testing
- `timeout 5s nose2 -s lib/python/qmk/tests -v` *(fails: lib/lvgl missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872efa14114832cb9df69b4ca1fa072