### PR TITLE
Add Vial feature controls for Holykeebs

### DIFF
--- a/keyboards/lily58/keymaps/vial/vial.json
+++ b/keyboards/lily58/keymaps/vial/vial.json
@@ -30,5 +30,18 @@
       [{"y":-0.975,"x":4},"4,2",{"x":7.5},"9,2", "9,1"],
       [{"y":-0.9,"x":5},"4,3",{"x":0.5, "h":1.5},"4,4",{"x":2.5,"h":1.5},"9,4",{"x":0.5},"9,3"]
     ]
-  }
+  },
+  "features": [
+    { "id":"scroll_mul_main",  "name":"Main Speed",      "type":"int",  "min":25,  "max":500, "step":5,  "default":125 },
+    { "id":"snipe_mul_main",   "name":"Main Sniping",    "type":"int",  "min":10,  "max":200, "step":5,  "default":100 },
+    { "id":"scroll_buf_main",  "name":"Main Scroll Buf", "type":"int",  "min":0,   "max":20,  "step":1,  "default":5  },
+    { "id":"drag_main",        "name":"Main Drag Scroll","type":"bool",                        "default":false },
+    { "id":"lock_main",        "name":"Main ScrollLock", "type":"enum", "options":["Off","H","V"], "default":0 },
+
+    { "id":"scroll_mul_peri",  "name":"Peri Speed",      "type":"int",  "min":25,  "max":500, "step":5,  "default":150 },
+    { "id":"snipe_mul_peri",   "name":"Peri Sniping",    "type":"int",  "min":10,  "max":200, "step":5,  "default":100 },
+    { "id":"scroll_buf_peri",  "name":"Peri Scroll Buf", "type":"int",  "min":0,   "max":20,  "step":1,  "default":5  },
+    { "id":"drag_peri",        "name":"Peri Drag Scroll","type":"bool",                        "default":true },
+    { "id":"lock_peri",        "name":"Peri ScrollLock", "type":"enum", "options":["Off","H","V"], "default":0 }
+  ]
 }

--- a/users/holykeebs/hk_vial.c
+++ b/users/holykeebs/hk_vial.c
@@ -1,0 +1,53 @@
+#include "vial.h"
+#include "holykeebs.h"
+#include "pointing.h"
+
+// FEATURE IDs – keep enum order in sync with vial.json
+enum {
+    FEAT_MAIN_DPI = 0,
+    FEAT_MAIN_SNIPE,
+    FEAT_MAIN_SCROLL_BUF,
+    FEAT_MAIN_DRAG,
+    FEAT_MAIN_SCROLL_LOCK,
+    FEAT_PERI_DPI,
+    FEAT_PERI_SNIPE,
+    FEAT_PERI_SCROLL_BUF,
+    FEAT_PERI_DRAG,
+    FEAT_PERI_SCROLL_LOCK,
+    FEAT_COUNT      // must be last
+};
+
+bool vial_user_feature_get(uint8_t id, void *data, uint8_t *sz) {
+    switch (id) {
+        case FEAT_MAIN_DPI:         *((uint8_t*)data)=g_hk_state.main.pointer_default_multiplier*100; *sz=1; return true;
+        case FEAT_MAIN_SNIPE:       *((uint8_t*)data)=g_hk_state.main.pointer_sniping_multiplier*100;  *sz=1; return true;
+        case FEAT_MAIN_SCROLL_BUF:  *((uint8_t*)data)=g_hk_state.main.pointer_scroll_buffer_size;      *sz=1; return true;
+        case FEAT_MAIN_DRAG:        *((bool  *)data)=g_hk_state.main.drag_scroll;                      *sz=1; return true;
+        case FEAT_MAIN_SCROLL_LOCK: *((uint8_t*)data)=g_hk_state.main.scroll_lock;                     *sz=1; return true;
+        case FEAT_PERI_DPI:         *((uint8_t*)data)=g_hk_state.peripheral.pointer_default_multiplier*100; *sz=1; return true;
+        case FEAT_PERI_SNIPE:       *((uint8_t*)data)=g_hk_state.peripheral.pointer_sniping_multiplier*100;  *sz=1; return true;
+        case FEAT_PERI_SCROLL_BUF:  *((uint8_t*)data)=g_hk_state.peripheral.pointer_scroll_buffer_size;      *sz=1; return true;
+        case FEAT_PERI_DRAG:        *((bool  *)data)=g_hk_state.peripheral.drag_scroll;                      *sz=1; return true;
+        case FEAT_PERI_SCROLL_LOCK: *((uint8_t*)data)=g_hk_state.peripheral.scroll_lock;                     *sz=1; return true;
+    }
+    return false;
+}
+
+bool vial_user_feature_set(uint8_t id, const void *data, uint8_t sz) {
+    if (sz!=1) return false;
+    switch (id) {
+        case FEAT_MAIN_DPI:         g_hk_state.main.pointer_default_multiplier      = *((uint8_t*)data)/100.0; break;
+        case FEAT_MAIN_SNIPE:       g_hk_state.main.pointer_sniping_multiplier      = *((uint8_t*)data)/100.0; break;
+        case FEAT_MAIN_SCROLL_BUF:  g_hk_state.main.pointer_scroll_buffer_size      = *((uint8_t*)data);       break;
+        case FEAT_MAIN_DRAG:        g_hk_state.main.drag_scroll                     = *((bool  *)data);        break;
+        case FEAT_MAIN_SCROLL_LOCK: g_hk_state.main.scroll_lock                     = *((uint8_t*)data);       break;
+        case FEAT_PERI_DPI:         g_hk_state.peripheral.pointer_default_multiplier= *((uint8_t*)data)/100.0; break;
+        case FEAT_PERI_SNIPE:       g_hk_state.peripheral.pointer_sniping_multiplier= *((uint8_t*)data)/100.0; break;
+        case FEAT_PERI_SCROLL_BUF:  g_hk_state.peripheral.pointer_scroll_buffer_size= *((uint8_t*)data);       break;
+        case FEAT_PERI_DRAG:        g_hk_state.peripheral.drag_scroll               = *((bool  *)data);        break;
+        case FEAT_PERI_SCROLL_LOCK: g_hk_state.peripheral.scroll_lock               = *((uint8_t*)data);       break;
+        default: return false;
+    }
+    g_hk_state.dirty = true;
+    return true;
+}

--- a/users/holykeebs/holykeebs.c
+++ b/users/holykeebs/holykeebs.c
@@ -684,3 +684,12 @@ void                       eeconfig_init_user(void) {
 
     printf("eeconfig_init_user: eeprom data written\n");
 }
+
+__attribute__((weak)) void matrix_scan_keymap(void) {}
+void matrix_scan_user(void) {
+    matrix_scan_keymap();
+    if (g_hk_state.dirty) {
+        write_eeconfig();
+        g_hk_state.dirty = false;
+    }
+}

--- a/users/holykeebs/rules.mk
+++ b/users/holykeebs/rules.mk
@@ -560,9 +560,12 @@ ifeq ($(strip $(OLED_FLIP)), yes)
 endif
 
 ifeq ($(strip $(TRACKBALL_RGB_RAINBOW)), yes)
-	OPT_DEFS += -DHK_PIMORONI_TRACKBALL_RGB_RAINBOW
-	SRC += quantum/color.c
+        OPT_DEFS += -DHK_PIMORONI_TRACKBALL_RGB_RAINBOW
+        SRC += quantum/color.c
 endif
+
+SRC += hk_vial.c
+VIAL_ENABLE = yes
 
 print-summary: cpfirmware
 	printf "\n%s" ' _           _       _             _         ' >&2


### PR DESCRIPTION
## Summary
- expose Holykeebs pointer settings to Vial
- enable Vial in user rules and board vial.json
- persist dirty state during matrix scan

## Testing
- `qmk compile -kb lily58/rev1 -km vial -e USER_NAME=holykeebs`

------
https://chatgpt.com/codex/tasks/task_e_6873d07f1114832c850a82636209c670