### PR TITLE
Fix release workflow docs and keymap examples

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 
 - Run `pytest -q` before committing changes to verify unit tests.
 - If tests fail due to missing dependencies, install them with `pip install -r requirements-dev.txt`.
-- The CI workflows build firmware from the `dev` branch by default, so ensure pull requests target `dev` unless otherwise noted.
+- The CI workflows run on the `dev` branch for regular testing. Create pull requests against `dev`.
+- Firmware releases are produced only when `dev` is merged into `main`.
 
 # Repo Guide for Codex Agents
 
@@ -44,7 +45,7 @@ This file provides instructions for OpenAI Codex (and similar agents) when worki
   ```
 - Manual make example:
   ```bash
-  make lily58/rev1:via -e USER_NAME=holykeebs \
+  make lily58/rev1:vial -e USER_NAME=holykeebs \
       -e POINTING_DEVICE=trackball_tps43 \
       -e SIDE=left \
       -e TRACKBALL_RGB_RAINBOW=yes \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,9 @@ qmk setup -y
 python build.py
 
 # Or use make directly
-make lily58/rev1:via -e USER_NAME=holykeebs -e POINTING_DEVICE=trackball_tps43
+make lily58/rev1:vial -e USER_NAME=holykeebs \
+  -e POINTING_DEVICE=trackball_tps43 \
+  -e VIAL_ENABLE=yes
 ```
 
 ## 🤝 Community Guidelines

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Each release includes:
 
 ### Firmware Naming Convention:
 ```
-lily58_rev1_via_[configuration]_[side].uf2
+lily58_rev1_vial_[configuration]_[side].uf2
 ```
 - `configuration`: The pointing device setup (e.g., `trackball_tps43`)
 - `side`: Either `left` or `right` for split keyboards
@@ -136,7 +136,7 @@ The `build.py` script supports various configurations:
 # Build specific configuration
 python build.py --build-single \
   --keyboard lily58/rev1 \
-  --keymap via \
+  --keymap vial \
   --left-device trackball \
   --right-device tps43
 
@@ -163,7 +163,7 @@ For direct QMK commands:
 
 ```bash
 # Dual pointing devices with Vial
-make lily58/rev1:via -e USER_NAME=holykeebs \
+make lily58/rev1:vial -e USER_NAME=holykeebs \
   -e POINTING_DEVICE=trackball_tps43 \
   -e SIDE=left \
   -e TRACKBALL_RGB_RAINBOW=yes \
@@ -178,7 +178,7 @@ When you fork this repository, you get automated firmware builds for free!
 1. Go to your fork's Settings → Actions
 2. Enable GitHub Actions if not already enabled
 3. The build workflow triggers on:
-   - Pull requests to `dev` or `main`
+   - Pushes to `main`
    - Tags matching `v*` pattern
    - Manual triggers via GitHub UI
 
@@ -201,6 +201,10 @@ We welcome contributions! Whether you want to:
 - Improve Vial integration
 - Fix bugs or optimize code
 - Add new keyboard layouts
+
+### Branch Workflow
+- Daily development occurs on the `dev` branch. Submit pull requests to `dev` so CI can test your changes.
+- When `dev` is merged into `main`, the firmware is built and a new release is created.
 
 ### How to Contribute:
 1. Fork this repository


### PR DESCRIPTION
## Summary
- run CI on dev per AGENTS guidelines
- ensure Release Drafter listens to PR edits
- update CONTRIBUTING example to use Vial keymap
- clarify build workflow triggers in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873e384b1ec832c91bc9cfb30eebfbc