### PR TITLE
Switch repo to uv for dependency management

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -61,10 +61,10 @@ jobs:
             unzip \
             wget \
             zip \
-            python3-pip
+            curl
 
-          pip3 install --upgrade pip
-          pip3 install qmk
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          uv pip install qmk
 
       - name: Build firmware
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/pip
+            ~/.cache/uv
             ~/qmk_firmware/.build
           key: ${{ runner.os }}-qmk-${{ hashFiles('**/requirements.txt') }}
 
@@ -77,8 +77,9 @@ jobs:
             binutils-avr \
             gcc-arm-none-eabi \
             gcc-avr \
-            python3-pip
-          pip3 install qmk
+            curl
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          uv pip install qmk
 
       - name: Test build configuration
         run: |
@@ -128,8 +129,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang graphviz
-          pip3 install pydot
+          sudo apt-get install -y clang graphviz curl
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          uv pip install pydot
       - name: Build call graphs
         run: |
           make callgraph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 # Repository Guidelines
 
 - Run `pytest -q` before committing changes to verify unit tests.
-- If tests fail due to missing dependencies, install them with `pip install -r requirements-dev.txt`.
+- If tests fail due to missing dependencies, install them with `uv pip install -r requirements-dev.txt`.
 - The CI workflows run on the `dev` branch for regular testing. Create pull requests against `dev`.
 - Firmware releases are produced only when `dev` is merged into `main`.
 
@@ -20,8 +20,9 @@ This file provides instructions for OpenAI Codex (and similar agents) when worki
 1. Install QMK dependencies. Example for Debian/Ubuntu:
    ```bash
    sudo apt-get update
-   sudo apt-get install -y git python3-pip
-   pip3 install qmk
+   sudo apt-get install -y git curl
+   curl -Ls https://astral.sh/uv/install.sh | bash
+   uv pip install qmk
    qmk setup -y
    ```
 2. Optionally use `shell.nix` for a reproducible environment (`nix-shell`).
@@ -57,7 +58,7 @@ This file provides instructions for OpenAI Codex (and similar agents) when worki
 - Install dev requirements and init submodules first:
   ```bash
   scripts/init_submodules.sh
-  pip install -r requirements-dev.txt
+  uv pip install -r requirements-dev.txt
   ```
 - Run tests and lint checks with `qmk pytest` (uses `nose2`, `flake8`, and `yapf`).
 - Format Python code with `qmk format-python`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,9 @@ You can use these commands in PR comments:
 brew install qmk/qmk/qmk
 
 # Install dependencies (Linux)
-sudo apt-get install -y git python3-pip
-pip3 install qmk
+sudo apt-get install -y git curl
+curl -Ls https://astral.sh/uv/install.sh | bash
+uv pip install qmk
 qmk setup -y
 ```
 

--- a/docs/ChangeLog/20220528.md
+++ b/docs/ChangeLog/20220528.md
@@ -50,7 +50,7 @@ On Windows, if using _QMK MSYS_ or _msys2_, you'll need to run the following com
 
 ```sh
 pacman --needed --noconfirm --disable-download-timeout -S mingw-w64-x86_64-python-pillow
-python3 -m pip install --upgrade qmk
+uv pip install --upgrade qmk
 ```
 
 On macOS:
@@ -63,7 +63,7 @@ brew upgrade qmk/qmk/qmk
 On Linux or WSL:
 
 ```sh
-python3 -m pip install --user --upgrade qmk
+uv pip install --user --upgrade qmk
 ```
 
 ### Updated Keyboard Codebases {#updated-keyboard-codebases}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,12 +18,12 @@ export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```
 
-### Install Using pip {#install-using-easy_install-or-pip}
+### Install Using uv {#install-using-easy_install-or-pip}
 
-If your system is not listed above you can install QMK manually. First ensure that you have Python 3.7 (or later) installed and have installed pip. Then install QMK with this command:
+If your system is not listed above you can install QMK manually. First ensure that you have Python 3.7 (or later) installed and have installed [uv](https://github.com/astral-sh/uv). Then install QMK with this command:
 
 ```
-python3 -m pip install qmk
+uv pip install qmk
 export QMK_HOME='~/qmk_firmware' # Optional, set the location for `qmk_firmware`
 qmk setup  # This will clone `qmk/qmk_firmware` and optionally set up your build environment
 ```

--- a/docs/cli_development.md
+++ b/docs/cli_development.md
@@ -15,7 +15,7 @@ If you intend to maintain keyboards and/or contribute to QMK, you can enable the
 This will allow you to see all available subcommands.  
 **Note:** You will have to install additional requirements:  
 ```
-python3 -m pip install -r requirements-dev.txt
+uv pip install -r requirements-dev.txt
 ```
 
 # Subcommands

--- a/docs/features/autocorrect.md
+++ b/docs/features/autocorrect.md
@@ -80,7 +80,7 @@ The solution is to set a word break : before and/or after the typo to constrain 
 
 :thier: is most restrictive, matching only when thier is a whole word.
 
-The `qmk generate-autocorrect-data` commands can make an effort to check for entries that would false trigger as substrings of correct words. It searches each typo against a dictionary of 25K English words from the english_words Python package, provided it’s installed. (run `python3 -m pip install english_words` to install it.)
+The `qmk generate-autocorrect-data` commands can make an effort to check for entries that would false trigger as substrings of correct words. It searches each typo against a dictionary of 25K English words from the english_words Python package, provided it’s installed. (run `uv pip install english_words` to install it.)
 
 ::: tip
 Unfortunately, this is limited to just english words, at this point.

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -85,20 +85,20 @@ brew install qmk/qmk/qmk
 
 You will need to install Git and Python. It's very likely that you already have both, but if not, one of the following commands should install them:
 
-* Debian / Ubuntu / Devuan: `sudo apt install -y git python3-pip`
-* Fedora / Red Hat / CentOS: `sudo yum -y install git python3-pip`
-* Arch / Manjaro: `sudo pacman --needed --noconfirm -S git python-pip libffi`
-* Void: `sudo xbps-install -y git python3-pip`
-* Solus: `sudo eopkg -y install git python3`
-* Sabayon: `sudo equo install dev-vcs/git dev-python/pip`
-* Gentoo: `sudo emerge dev-vcs/git dev-python/pip`
+* Debian / Ubuntu / Devuan: `sudo apt install -y git curl`
+* Fedora / Red Hat / CentOS: `sudo yum -y install git curl`
+* Arch / Manjaro: `sudo pacman --needed --noconfirm -S git curl libffi`
+* Void: `sudo xbps-install -y git curl`
+* Solus: `sudo eopkg -y install git curl`
+* Sabayon: `sudo equo install dev-vcs/git net-misc/curl`
+* Gentoo: `sudo emerge dev-vcs/git net-misc/curl`
 
 #### Installation
 
 Install the QMK CLI by running:
 
 ```sh
-python3 -m pip install --user qmk
+uv pip install --user qmk
 ```
 
 #### Community Packages

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ To run the unit tests locally:
 
 2. Install dependencies:
    ```bash
-   pip install -r requirements-dev.txt
+   uv pip install -r requirements-dev.txt
    ```
 
 3. Run the suite:
@@ -112,8 +112,9 @@ lily58_rev1_vial_[configuration]_[side].uf2
    
    # Linux/WSL
    sudo apt-get update
-   sudo apt-get install -y git python3-pip
-   pip3 install qmk
+   sudo apt-get install -y git curl
+   curl -Ls https://astral.sh/uv/install.sh | bash
+   uv pip install qmk
    qmk setup -y
    ```
 

--- a/util/install/arch.sh
+++ b/util/install/arch.sh
@@ -4,7 +4,7 @@ _qmk_install() {
     echo "Installing dependencies"
 
     sudo pacman --needed  --noconfirm -S \
-        base-devel clang diffutils gcc git unzip wget zip python-pip \
+        base-devel clang diffutils gcc git unzip wget zip curl \
         avr-binutils arm-none-eabi-binutils arm-none-eabi-gcc \
         arm-none-eabi-newlib avrdude dfu-programmer dfu-util \
         riscv64-elf-binutils riscv64-elf-gcc riscv64-elf-newlib
@@ -13,5 +13,6 @@ _qmk_install() {
 
     sudo pacman --needed  --noconfirm -S hidapi  # This will fail if the community repo isn't enabled
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/debian.sh
+++ b/util/install/debian.sh
@@ -13,7 +13,7 @@ _qmk_install() {
 
     sudo apt-get --quiet --yes install \
         build-essential clang-format diffutils gcc git unzip wget zip \
-        python3-pip binutils-avr gcc-avr avr-libc binutils-arm-none-eabi \
+        curl binutils-avr gcc-avr avr-libc binutils-arm-none-eabi \
         gcc-arm-none-eabi libnewlib-arm-none-eabi avrdude dfu-programmer \
         dfu-util teensy-loader-cli libhidapi-hidraw0 libusb-dev
 
@@ -24,5 +24,6 @@ _qmk_install() {
             binutils-riscv64-unknown-elf
     fi
 
-    python3 -m pip install --user -r "$QMK_FIRMWARE_DIR"/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r "$QMK_FIRMWARE_DIR"/requirements.txt
 }

--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -21,5 +21,6 @@ _qmk_install() {
         || sudo dnf $SKIP_PROMPT install libusb1-devel libusb-compat-0.1-devel \
         || sudo dnf $SKIP_PROMPT install libusb0-devel
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/freebsd.sh
+++ b/util/install/freebsd.sh
@@ -14,5 +14,6 @@ _qmk_install() {
         arm-none-eabi-binutils arm-none-eabi-gcc arm-none-eabi-newlib \
         avrdude dfu-programmer dfu-util
 
-    sudo python3 -m pip install -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    sudo uv pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/gentoo.sh
+++ b/util/install/gentoo.sh
@@ -30,5 +30,6 @@ _qmk_install() {
     sudo crossdev -s4 --stable --g \<9 --portage --verbose --target avr
     sudo crossdev -s4 --stable --g \<9 --portage --verbose --target arm-none-eabi
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/slackware.sh
+++ b/util/install/slackware.sh
@@ -21,5 +21,6 @@ _qmk_install() {
         python3 \
         avrdude dfu-programmer dfu-util teensy_loader_cli
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/solus.sh
+++ b/util/install/solus.sh
@@ -15,5 +15,6 @@ _qmk_install() {
         arm-none-eabi-binutils arm-none-eabi-gcc arm-none-eabi-newlib \
         avrdude dfu-programmer dfu-util
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }

--- a/util/install/void.sh
+++ b/util/install/void.sh
@@ -5,11 +5,12 @@ _qmk_install() {
 
     sudo xbps-install $SKIP_PROMPT \
         gcc git make wget unzip zip \
-        python3-pip \
+        curl \
         avr-binutils avr-gcc avr-libc \
         cross-arm-none-eabi-binutils cross-arm-none-eabi-gcc cross-arm-none-eabi-newlib \
         avrdude dfu-programmer dfu-util teensy_loader_cli \
         libusb-compat-devel
 
-    python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    uv pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
## Summary
- use `uv` instead of pip in docs and AGENTS instructions
- update GitHub Actions workflows to install uv and use `uv pip`
- replace pip commands in install scripts
- document uv usage in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873efb79988832cba02ccbf06beb47d