### PR TITLE
Fix qmk setup in CI workflows

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -65,6 +65,8 @@ jobs:
 
           pip3 install --upgrade pip
           pip3 install qmk
+          pip3 install -r requirements.txt
+          qmk setup -y
 
       - name: Build firmware
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,6 +79,8 @@ jobs:
             gcc-avr \
             python3-pip
           pip3 install qmk
+          pip3 install -r requirements.txt
+          qmk setup -y
 
       - name: Test build configuration
         run: |


### PR DESCRIPTION
## Summary
- ensure QMK CLI is fully initialized before building firmware
- install repo requirements in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768d6ba308832ca79a9c00482a704d