### PR TITLE
Fix qmk path with pipx

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -63,8 +63,10 @@ jobs:
             zip \
             python3-pip
 
-          pip3 install --upgrade pip
-          pip3 install qmk
+          pip3 install --user -U pipx
+          pipx install --force qmk
+          pipx runpip qmk install -r requirements.txt
+          pipx run qmk setup -y
 
       - name: Build firmware
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,10 @@ jobs:
             gcc-arm-none-eabi \
             gcc-avr \
             python3-pip
-          pip3 install qmk
+          pip3 install --user -U pipx
+          pipx install --force qmk
+          pipx runpip qmk install -r requirements.txt
+          pipx run qmk setup -y
 
       - name: Test build configuration
         run: |


### PR DESCRIPTION
## Summary
- install qmk via pipx so the full CLI is available
- run setup using pipx-installed qmk

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768d6ba308832ca79a9c00482a704d