### PR TITLE
fix: streamline uv setup

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -63,13 +63,17 @@ jobs:
             zip \
             python3-pip
 
-          pip3 install --upgrade pip
-          pip3 install qmk
+          uv venv
+          source .venv/bin/activate
+          uv tool install qmk
+          uv pip install -r requirements.txt
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Build firmware
         run: |
           # Use the current repository as the QMK environment
           qmk config user.qmk_home=$GITHUB_WORKSPACE
+          qmk config user.userspace=holykeebs
           qmk config user.keyboard=${{ matrix.keyboard }}
           qmk config user.keymap=${{ matrix.keymap }}
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,11 +78,16 @@ jobs:
             gcc-arm-none-eabi \
             gcc-avr \
             python3-pip
-          pip3 install qmk
+          uv venv
+          source .venv/bin/activate
+          uv tool install qmk
+          uv pip install -r requirements.txt
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Test build configuration
         run: |
           qmk config user.qmk_home=$GITHUB_WORKSPACE
+          qmk config user.userspace=holykeebs
           python build.py --build-single \
             --keyboard "${{ matrix.keyboard }}" \
             --keymap "${{ matrix.keymap }}" \


### PR DESCRIPTION
## Summary
- install QMK with uv without running `qmk setup`
- keep `.venv/bin` on PATH for all build steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68768d6ba308832ca79a9c00482a704d