### PR TITLE
fix: install qmk with uv

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -63,13 +63,19 @@ jobs:
             zip \
             python3-pip
 
-          pip3 install --upgrade pip
-          pip3 install qmk
+          pip install uv
+          uv venv
+          source .venv/bin/activate
+          uv tool install qmk
+          uv pip install -r requirements.txt
+          qmk setup -y
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Build firmware
         run: |
           # Use the current repository as the QMK environment
           qmk config user.qmk_home=$GITHUB_WORKSPACE
+          qmk config user.userspace=holykeebs
           qmk config user.keyboard=${{ matrix.keyboard }}
           qmk config user.keymap=${{ matrix.keymap }}
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,11 +78,18 @@ jobs:
             gcc-arm-none-eabi \
             gcc-avr \
             python3-pip
-          pip3 install qmk
+          pip install uv
+          uv venv
+          source .venv/bin/activate
+          uv tool install qmk
+          uv pip install -r requirements.txt
+          qmk setup -y
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Test build configuration
         run: |
           qmk config user.qmk_home=$GITHUB_WORKSPACE
+          qmk config user.userspace=holykeebs
           python build.py --build-single \
             --keyboard "${{ matrix.keyboard }}" \
             --keymap "${{ matrix.keymap }}" \


### PR DESCRIPTION
## Summary
- revert accidental addition of QMK CLI sources
- install qmk using `uv` and run `qmk setup` in workflows
- configure the `holykeebs` userspace for builds

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68768d6ba308832ca79a9c00482a704d